### PR TITLE
Only search for scenes in assets folder

### DIFF
--- a/Plugins/AssetUsageDetector/Editor/AssetUsageDetector.cs
+++ b/Plugins/AssetUsageDetector/Editor/AssetUsageDetector.cs
@@ -282,7 +282,7 @@ namespace AssetUsageDetectorNamespace
 				else if( ( searchParameters.searchInScenes & SceneSearchMode.AllScenes ) == SceneSearchMode.AllScenes )
 				{
 					// Get all scenes from the Assets folder
-					string[] sceneGuids = AssetDatabase.FindAssets( "t:SceneAsset" );
+					string[] sceneGuids = AssetDatabase.FindAssets( "t:SceneAsset", new string [] { "Assets" } );
 					for( int i = 0; i < sceneGuids.Length; i++ )
 						scenesToSearch.Add( AssetDatabase.GUIDToAssetPath( sceneGuids[i] ) );
 				}


### PR DESCRIPTION
Avoids searching for scenes in packages folder which might be readonly and throw an exception when trying to open them.

See https://github.com/yasirkula/UnityAssetUsageDetector/issues/36